### PR TITLE
Updating README to add note about it's use in Phoenix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@ pipeline :api do
 end
 ```
 
+It should be noted that Phoenix pipelines are only invoked for matched routes, so you will need to add `options` routes for your API endpoints. Leaving this out will cause the `plug` to not be called and the response will be a 404.
+
+```elixir
+scope "/api", PhoenixApp do
+  pipe_through :api
+
+  resources "/articles", ArticleController
+  options   "/articles", ArticleController, :options
+  options   "/articles/:id", ArticleController, :options
+end
+```
+
 ## Configuration
 
 This plug will return the following headers:


### PR DESCRIPTION
I ran into some difficulty using this plug because it wasn't being invoked, but I was instead receiving 404s. After chatting with Chris McCord he let me know that pipelines are only invoked for matched routes. By adding options routes, it would correctly call the pipeline and therefore the CORSPlug plug.

I just wanted to add that to the README as it took me a little while to figure out!