### PR TITLE
Add access-control-expose-headers header

### DIFF
--- a/lib/cors_plug.ex
+++ b/lib/cors_plug.ex
@@ -10,6 +10,7 @@ defmodule CORSPlug do
                     "User-Agent", "DNT","Cache-Control", "X-Mx-ReqToken",
                     "Keep-Alive", "X-Requested-With", "If-Modified-Since",
                     "X-CSRF-Token"],
+      expose:      [],
       methods:     ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
     ]
   end
@@ -37,6 +38,7 @@ defmodule CORSPlug do
   defp headers(conn, options) do
     [
       {"access-control-allow-origin", origin(options[:origin], conn)},
+      {"access-control-expose-headers", origin(options[:expose], conn)},
       {"access-control-allow-credentials", "#{options[:credentials]}"}
     ]
   end

--- a/test/cors_plug_test.exs
+++ b/test/cors_plug_test.exs
@@ -34,6 +34,7 @@ defmodule CORSPlugTest do
 
     assert headers == [
       "access-control-allow-origin",
+      "access-control-expose-headers",
       "access-control-allow-credentials",
       "access-control-max-age",
       "access-control-allow-headers",


### PR DESCRIPTION
[This header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Access-Control-Expose-Headers) is another import CORS header that allows browsers to have access to custom headers that come back in the response.

A common use case is a `Link` header that returns [pagination information](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Access-Control-Expose-Headers)