### PR TITLE
Updates README to use latest Phoenix endpoint.ex syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ defmodule YourApp.Endpoint do
   # ...
   plug CORSPlug
 
-  plug :router, YourApp.Router
+  plug YourApp.Router
 end
 ```
 


### PR DESCRIPTION
Hey @mschae, great work on this CORS Plug!

Here's a small update to the README to use the latest Phoenix syntax. Looks like `Plug :router, MyApp.Router` is deprecated in newer releases. Confirmed the new line works in a Phoenix application.

Here's @chrismccord's comment on the syntax change: https://github.com/phoenixframework/phoenix/issues/1142#issuecomment-132749283