### PR TITLE
Expose Headers

### DIFF
--- a/lib/cors_plug.ex
+++ b/lib/cors_plug.ex
@@ -38,7 +38,7 @@ defmodule CORSPlug do
   defp headers(conn, options) do
     [
       {"access-control-allow-origin", origin(options[:origin], conn)},
-      {"access-control-expose-headers", origin(options[:expose], conn)},
+      {"access-control-expose-headers", Enum.join(options[:expose], ",")},
       {"access-control-allow-credentials", "#{options[:credentials]}"}
     ]
   end
@@ -52,4 +52,5 @@ defmodule CORSPlug do
   end
 
   defp origin(origin, _conn), do: origin
+
 end

--- a/test/cors_plug_test.exs
+++ b/test/cors_plug_test.exs
@@ -2,7 +2,6 @@ defmodule CORSPlugTest do
   use ExUnit.Case
   use Plug.Test
 
-
   test "returns the right options for regular requests" do
     opts = CORSPlug.init([])
     conn = conn(:get, "/")
@@ -51,5 +50,14 @@ defmodule CORSPlugTest do
 
     assert Enum.member? conn.resp_headers,
                         {"access-control-allow-origin", "http://cors-plug.example"}
+  end
+
+  test "exposed headers are returned" do
+    opts = CORSPlug.init(expose: ["content-range", "content-length", "accept-ranges"])
+    conn = conn(:options, "/")
+
+    conn = CORSPlug.call(conn, opts)
+
+    assert get_resp_header(conn, "access-control-expose-headers") == ["content-range,content-length,accept-ranges"]
   end
 end


### PR DESCRIPTION
I thought it was weird that expose-headers was being run through the origin method. The `expose-headers` are also supposed to be a comma separated list like the `allow-headers`, since you've joined the `allow-headers` into a string, I followed that pattern.