### PR TITLE
Allow multiple origins to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ On `GET`, `POST`, ... requests:
 You can configure the value of these headers as follows:
 
 ```elixir
-plug CORSPlug, [origin: "example.com"]
+plug CORSPlug, [origins: ["example.com"]]
 ```
 
 Please find the list of current defaults in [cors_plug.ex](lib/cors_plug.ex#L5:L13).

--- a/lib/cors_plug.ex
+++ b/lib/cors_plug.ex
@@ -3,7 +3,7 @@ defmodule CORSPlug do
 
   def defaults do
     [
-      origin:      "*",
+      origins:     ["*"],
       credentials: true,
       max_age:     1728000,
       headers:     ["Authorization", "Content-Type", "Accept", "Origin",
@@ -37,13 +37,13 @@ defmodule CORSPlug do
 
   defp headers(conn, options) do
     [
-      {"access-control-allow-origin", origin(options[:origin], conn)},
+      {"access-control-allow-origin", origin(options[:origins], conn)},
       {"access-control-expose-headers", origin(options[:expose], conn)},
       {"access-control-allow-credentials", "#{options[:credentials]}"}
     ]
   end
 
-  defp origin(:self, conn) do
+  defp origin([:self], conn) do
     {_, host} =
       Enum.find(conn.req_headers,
                 {nil, "*"},
@@ -51,5 +51,11 @@ defmodule CORSPlug do
     host
   end
 
-  defp origin(origin, _conn), do: origin
+  defp origin(["*"], _conn), do: "*"
+
+  defp origin(origins, conn) do
+    req_origin = get_req_header(conn, "origin") |> List.first
+    Enum.find(origins, fn(origin) -> origin == req_origin end)
+  end
+
 end


### PR DESCRIPTION
This is a fix for https://github.com/mschae/cors_plug/issues/12.
Trying what you suggested in the issue didn't resolve the issue. I did `plug CORSPlug, origin: "http://localhost:8080 http://localhost:8880 http://localhost:8888"`

And received this error
![screen shot 2016-02-09 at 3 20 51 pm](https://cloud.githubusercontent.com/assets/1280586/12934085/e82b776e-cf40-11e5-891e-42b4de3414c1.png)

The definition for [Access-Control-Allow-Origin](https://www.w3.org/TR/cors/#access-control-allow-origin-response-header) says `Note: In practice the origin-list-or-null production is more constrained. Rather than allowing a space-separated list of origins, it is either a single origin or the string "null".` so I made changes to implement that.