### PR TITLE
Fix return value for origin when none matched

### DIFF
--- a/test/cors_plug_test.exs
+++ b/test/cors_plug_test.exs
@@ -52,12 +52,12 @@ defmodule CORSPlugTest do
            get_resp_header(conn, "access-control-allow-origin")
   end
 
-  test "returns nil when the origin is invalid" do
+  test "returns null string when the origin is invalid" do
     opts = CORSPlug.init(origin: ["example1.com"])
     conn = conn(:get, "/", nil, headers: [{"origin", "example2.com"}])
 
     conn = CORSPlug.call(conn, opts)
-    assert [nil] == get_resp_header conn, "access-control-allow-origin"
+    assert ["null"] == get_resp_header conn, "access-control-allow-origin"
   end
 
   test "returns the request host when origin is :self" do


### PR DESCRIPTION
This fixes `[error] Bad value on output port 'tcp_inet'` when request origin is not in allowed origins, by returning `"null"` string, instead of nil, which I believe is not a valid value for this header. See: https://www.w3.org/TR/cors/#access-control-allow-origin-response-header

Not entirely sure of the implications. Thoughts?
