### PR TITLE
Copy request-headers to allow-headers for a wildcard headers option.

### DIFF
--- a/lib/cors_plug.ex
+++ b/lib/cors_plug.ex
@@ -31,7 +31,7 @@ defmodule CORSPlug do
   defp headers(conn = %Plug.Conn{method: "OPTIONS"}, options) do
     headers(%{conn | method: nil}, options) ++ [
       {"access-control-max-age", "#{options[:max_age]}"},
-      {"access-control-allow-headers", Enum.join(options[:headers], ",")},
+      {"access-control-allow-headers", allowed_headers(options[:headers], conn)},
       {"access-control-allow-methods", Enum.join(options[:methods], ",")}
     ]
   end
@@ -43,6 +43,16 @@ defmodule CORSPlug do
       {"access-control-expose-headers", Enum.join(options[:expose], ",")},
       {"access-control-allow-credentials", "#{options[:credentials]}"}
     ]
+  end
+
+  # Allow all requested headers
+  defp allowed_headers(["*"], conn) do
+    get_req_header(conn, "access-control-request-headers")
+    |> List.first
+  end
+
+  defp allowed_headers(key, _conn) do
+    Enum.join(key, ",")
   end
 
   # normalize non-list to list

--- a/test/cors_plug_test.exs
+++ b/test/cors_plug_test.exs
@@ -12,7 +12,6 @@ defmodule CORSPlugTest do
     assert ["*"] == get_resp_header conn, "access-control-allow-origin"
   end
 
-
   test "lets me overwrite options" do
     opts = CORSPlug.init(origin: "example.com")
     conn = conn(:get, "/", nil, headers: [{"origin", "example.com"}])
@@ -72,12 +71,23 @@ defmodule CORSPlugTest do
   end
 
   test "exposed headers are returned" do
-     opts = CORSPlug.init(expose: ["content-range", "content-length", "accept-ranges"])
-     conn = conn(:options, "/")
+    opts = CORSPlug.init(expose: ["content-range", "content-length", "accept-ranges"])
+    conn = conn(:options, "/")
 
-     conn = CORSPlug.call(conn, opts)
+    conn = CORSPlug.call(conn, opts)
 
-     assert get_resp_header(conn, "access-control-expose-headers") ==
-            ["content-range,content-length,accept-ranges"]
-   end
+    assert get_resp_header(conn, "access-control-expose-headers") ==
+      ["content-range,content-length,accept-ranges"]
+  end
+
+  test "allows all incoming headers" do
+    opts = CORSPlug.init(headers: ["*"])
+    conn = conn(:options, "/", nil,
+                headers: [{"access-control-request-headers", "custom-header,upgrade-insecure-requests"}])
+
+    conn = CORSPlug.call(conn, opts)
+
+    assert get_resp_header(conn, "access-control-allow-headers") ==
+      ["custom-header,upgrade-insecure-requests"]
+  end
 end


### PR DESCRIPTION
Hi,

this pull request adds support for wildcard headers - it will copy headers from `access-control-request-headers` to `access-control-allow-headers`. I've also fixed indentation in few places.

I'm not sure if that's something you'd like to support in this library and I guess my use case is unique so feel free to just close it :) In my use case, I need to be able to allow arbitrary requests, outside my control, server is just a proxy. 

Cheers,
Michał