### PR TITLE
Allow wildcard in list of origins with whitelist domains.

### DIFF
--- a/lib/cors_plug.ex
+++ b/lib/cors_plug.ex
@@ -93,7 +93,11 @@ defmodule CORSPlug do
   # see: https://www.w3.org/TR/cors/#access-control-allow-origin-response-header
   defp origin(origins, conn) when is_list(origins) do
     req_origin = request_origin(conn)
-    if req_origin in origins, do: req_origin, else: "null"
+    cond do
+      req_origin in origins -> req_origin
+      "*" in origins        -> "*"
+      true                  -> "null"
+    end
   end
 
   defp request_origin(%Plug.Conn{req_headers: headers}) do

--- a/test/cors_plug_test.exs
+++ b/test/cors_plug_test.exs
@@ -68,7 +68,7 @@ defmodule CORSPlugTest do
   end
 
   test "returns the origin when origin is in origin option list" do
-    opts = CORSPlug.init(origin: ["example1.com", "example2.com"])
+    opts = CORSPlug.init(origin: ["example1.com", "example2.com", "*"])
     conn =
       :get
       |> conn("/")
@@ -77,6 +77,17 @@ defmodule CORSPlugTest do
     conn = CORSPlug.call(conn, opts)
     assert assert ["example2.com"] ==
            get_resp_header(conn, "access-control-allow-origin")
+  end
+
+  test "returns * string when the origin * in the list" do
+    opts = CORSPlug.init(origin: ["example1.com", "*"])
+    conn =
+      :get
+      |> conn("/")
+      |> put_req_header("origin", "example2.com")
+
+    conn = CORSPlug.call(conn, opts)
+    assert ["*"] == get_resp_header conn, "access-control-allow-origin"
   end
 
   test "returns null string when origin is not in origin option list" do


### PR DESCRIPTION
Sometimes we need to specify for both whitelisted domains and wildcard(*) in the origins list. 

For example, I want to send credential flag only specific host but also want to enable other resources to wildcard.

To pass cookie headers from other host, server should respond with 'Access-Control-Allow-Origin' equal to the request origin. A wildcard '*' cannot be used in the 'Access-Control-Allow-Origin' header when the credentials flag is true. 

Details:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Requests_with_credentials
