### PR TITLE
Allow origin option

### DIFF
--- a/lib/cors_plug.ex
+++ b/lib/cors_plug.ex
@@ -74,7 +74,12 @@ defmodule CORSPlug do
   # see: https://www.w3.org/TR/cors/#access-control-allow-origin-response-header
   defp origin(origins, conn) when is_list(origins) do
     origin = first_origin(conn)
-    if origin in origins, do: origin, else: "null"
+    if origin do
+      %{host: host} = URI.parse(origin)
+      if host in origins, do: origin, else: "null"
+    else
+      "null"
+    end
   end
 
   defp first_origin(conn) do

--- a/lib/cors_plug.ex
+++ b/lib/cors_plug.ex
@@ -62,7 +62,7 @@ defmodule CORSPlug do
 
   # whitelist internal requests
   defp origin([:self], conn) do
-    get_req_header(conn, "origin") |> List.first || "*"
+    first_origin(conn) || "*"
   end
 
   # return "*" if origin list is ["*"]
@@ -73,7 +73,13 @@ defmodule CORSPlug do
   # return request origin if in origin list, otherwise "null" string
   # see: https://www.w3.org/TR/cors/#access-control-allow-origin-response-header
   defp origin(origins, conn) when is_list(origins) do
-    req_origin = get_req_header(conn, "origin") |> List.first
-    if req_origin in origins, do: req_origin, else: "null"
+    origin = first_origin(conn)
+    if origin in origins, do: origin, else: "null"
+  end
+
+  defp first_origin(conn) do
+    get_req_header(conn, "origin")
+    |> Enum.concat(get_req_header(conn, "Origin"))
+    |> List.first
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,7 @@
-%{"cowboy": {:hex, :cowboy, "1.0.0"},
-  "cowlib": {:hex, :cowlib, "1.0.1"},
-  "earmark": {:hex, :earmark, "0.2.1"},
-  "ex_doc": {:hex, :ex_doc, "0.11.3"},
-  "plug": {:hex, :plug, "0.10.0"},
-  "ranch": {:hex, :ranch, "1.0.0"}}
+%{"cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:rebar, :make], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
+  "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
+  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.11.3", "bb16cb3f4135d880ce25279dc19a9d70802bc4f4942f0c3de9e4862517ae3ace", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
+  "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
+  "plug": {:hex, :plug, "1.2.2", "cfbda521b54c92ab8ddffb173fbaabed8d8fc94bec07cd9bb58a84c1c501b0bd", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
+  "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []}}

--- a/test/cors_plug_test.exs
+++ b/test/cors_plug_test.exs
@@ -14,11 +14,11 @@ defmodule CORSPlugTest do
 
   test "lets me overwrite options" do
     opts = CORSPlug.init(origin: "example.com")
-    conn = conn(:get, "/") |> put_req_header("origin", "example.com")
+    conn = conn(:get, "/") |> put_req_header("origin", "http://example.com")
 
     conn = CORSPlug.call(conn, opts)
 
-    assert ["example.com"] ==
+    assert ["http://example.com"] ==
            get_resp_header(conn, "access-control-allow-origin")
   end
 
@@ -44,25 +44,34 @@ defmodule CORSPlugTest do
 
   test "returns the origin when it is valid" do
     opts = CORSPlug.init(origin: ["example1.com", "example2.com"])
-    conn = conn(:get, "/") |> put_req_header("origin", "example1.com")
+    conn = conn(:get, "/") |> put_req_header("origin", "http://example1.com")
 
     conn = CORSPlug.call(conn, opts)
-    assert assert ["example1.com"] ==
+    assert assert ["http://example1.com"] ==
+           get_resp_header(conn, "access-control-allow-origin")
+  end
+
+  test "returns the origin even with other port" do
+    opts = CORSPlug.init(origin: ["example1.com", "example2.com"])
+    conn = conn(:get, "/") |> put_req_header("origin", "http://example1.com:8000")
+
+    conn = CORSPlug.call(conn, opts)
+    assert assert ["http://example1.com:8000"] ==
            get_resp_header(conn, "access-control-allow-origin")
   end
 
   test "returns the origin when header is uppercase (Origin)" do
     opts = CORSPlug.init(origin: ["example1.com", "example2.com"])
-    conn = conn(:get, "/") |> Map.put(:req_headers, [{"Origin", "example1.com"}])
+    conn = conn(:get, "/") |> Map.put(:req_headers, [{"Origin", "http://example1.com"}])
 
     conn = CORSPlug.call(conn, opts)
-    assert assert ["example1.com"] ==
+    assert assert ["http://example1.com"] ==
            get_resp_header(conn, "access-control-allow-origin")
   end
 
   test "returns null string when the origin is invalid" do
     opts = CORSPlug.init(origin: ["example1.com"])
-    conn = conn(:get, "/") |> put_req_header("origin", "example2.com")
+    conn = conn(:get, "/") |> put_req_header("origin", "http://example2.com")
 
     conn = CORSPlug.call(conn, opts)
     assert ["null"] == get_resp_header conn, "access-control-allow-origin"

--- a/test/cors_plug_test.exs
+++ b/test/cors_plug_test.exs
@@ -1,7 +1,7 @@
 defmodule CORSPlugTest do
   use ExUnit.Case
   use Plug.Test
-  import Plug.Conn, only: [get_resp_header: 2]
+  import Plug.Conn, only: [get_resp_header: 2, put_req_header: 3]
 
   test "returns the right options for regular requests" do
     opts = CORSPlug.init([])
@@ -14,7 +14,7 @@ defmodule CORSPlugTest do
 
   test "lets me overwrite options" do
     opts = CORSPlug.init(origin: "example.com")
-    conn = conn(:get, "/", nil, headers: [{"origin", "example.com"}])
+    conn = conn(:get, "/") |> put_req_header("origin", "example.com")
 
     conn = CORSPlug.call(conn, opts)
 
@@ -44,7 +44,16 @@ defmodule CORSPlugTest do
 
   test "returns the origin when it is valid" do
     opts = CORSPlug.init(origin: ["example1.com", "example2.com"])
-    conn = conn(:get, "/", nil, headers: [{"origin", "example1.com"}])
+    conn = conn(:get, "/") |> put_req_header("origin", "example1.com")
+
+    conn = CORSPlug.call(conn, opts)
+    assert assert ["example1.com"] ==
+           get_resp_header(conn, "access-control-allow-origin")
+  end
+
+  test "returns the origin when header is uppercase (Origin)" do
+    opts = CORSPlug.init(origin: ["example1.com", "example2.com"])
+    conn = conn(:get, "/") |> Map.put(:req_headers, [{"Origin", "example1.com"}])
 
     conn = CORSPlug.call(conn, opts)
     assert assert ["example1.com"] ==
@@ -53,7 +62,7 @@ defmodule CORSPlugTest do
 
   test "returns null string when the origin is invalid" do
     opts = CORSPlug.init(origin: ["example1.com"])
-    conn = conn(:get, "/", nil, headers: [{"origin", "example2.com"}])
+    conn = conn(:get, "/") |> put_req_header("origin", "example2.com")
 
     conn = CORSPlug.call(conn, opts)
     assert ["null"] == get_resp_header conn, "access-control-allow-origin"
@@ -61,8 +70,7 @@ defmodule CORSPlugTest do
 
   test "returns the request host when origin is :self" do
     opts = CORSPlug.init(origin: [:self])
-    conn = conn(:get, "/", nil,
-                headers: [{"origin", "http://cors-plug.example"}])
+    conn = conn(:get, "/") |> put_req_header("origin", "http://cors-plug.example")
 
     conn = CORSPlug.call(conn, opts)
 
@@ -82,8 +90,7 @@ defmodule CORSPlugTest do
 
   test "allows all incoming headers" do
     opts = CORSPlug.init(headers: ["*"])
-    conn = conn(:options, "/", nil,
-                headers: [{"access-control-request-headers", "custom-header,upgrade-insecure-requests"}])
+    conn = conn(:options, "/") |> put_req_header("access-control-request-headers", "custom-header,upgrade-insecure-requests")
 
     conn = CORSPlug.call(conn, opts)
 


### PR DESCRIPTION
I faced a problem when setting origin option in the plug, but after some consideration I found out that this was not properly set for allowing only specific origins.

First of all, the origin uses to come from request with capital O (Origin) and it was not getting this. Second place, it usually comes as a complete URI, so I changed the code to parse the URI coming from Origin and check only the host against the ones defined on origin.

I am not sure if I made something that would not cover other cases here, but I have put it to production and it is working just fine for me...
