### PR TITLE
Add Vary to response header.

### DIFF
--- a/lib/cors_plug.ex
+++ b/lib/cors_plug.ex
@@ -38,10 +38,13 @@ defmodule CORSPlug do
 
   # universal headers
   defp headers(conn, options) do
+    allowed_origin = origin(options[:origin], conn)
+
     [
-      {"access-control-allow-origin", origin(options[:origin], conn)},
+      {"access-control-allow-origin", allowed_origin},
       {"access-control-expose-headers", Enum.join(options[:expose], ",")},
-      {"access-control-allow-credentials", "#{options[:credentials]}"}
+      {"access-control-allow-credentials", "#{options[:credentials]}"},
+      {"vary", vary(allowed_origin)}
     ]
   end
 
@@ -86,4 +89,9 @@ defmodule CORSPlug do
   defp request_origin(%Plug.Conn{req_headers: headers}) do
     Enum.find_value(headers, fn({k, v}) -> k =~ ~r/origin/i && v end)
   end
+
+  # Set the Vary response header
+  # see: https://www.w3.org/TR/cors/#resource-implementation
+  defp vary("*"), do: ""
+  defp vary(_allowed_origin), do: "Origin"
 end

--- a/test/cors_plug_test.exs
+++ b/test/cors_plug_test.exs
@@ -159,27 +159,25 @@ defmodule CORSPlugTest do
       ["custom-header,upgrade-insecure-requests"]
   end
 
-  describe "the Vary response header" do
-    test "include Origin if the Access-Control-Allow-Origin is not `*`" do
-      opts = CORSPlug.init(origin: "http://example.com")
-      conn =
-        :get
-        |> conn("/")
-        |> put_req_header("origin", "null-example42.com")
+  test "include Origin in Vary response header if the Access-Control-Allow-Origin is not `*`" do
+    opts = CORSPlug.init(origin: "http://example.com")
+    conn =
+      :get
+      |> conn("/")
+      |> put_req_header("origin", "null-example42.com")
 
-      conn = CORSPlug.call(conn, opts)
-      assert ["Origin"] == get_resp_header conn, "vary"
-    end
+    conn = CORSPlug.call(conn, opts)
+    assert ["Origin"] == get_resp_header conn, "vary"
+  end
 
-    test "dont include Origin if the Access-Control-Allow-Origin is `*`" do
-      opts = CORSPlug.init(origin: "*")
-      conn =
-        :get
-        |> conn("/")
-        |> put_req_header("origin", "null-example42.com")
+  test "dont include Origin in Vary response header if the Access-Control-Allow-Origin is `*`" do
+    opts = CORSPlug.init(origin: "*")
+    conn =
+      :get
+      |> conn("/")
+      |> put_req_header("origin", "null-example42.com")
 
-      conn = CORSPlug.call(conn, opts)
-      assert [""] == get_resp_header conn, "vary"
-    end
+    conn = CORSPlug.call(conn, opts)
+    assert [""] == get_resp_header conn, "vary"
   end
 end

--- a/test/cors_plug_test.exs
+++ b/test/cors_plug_test.exs
@@ -158,4 +158,28 @@ defmodule CORSPlugTest do
     assert get_resp_header(conn, "access-control-allow-headers") ==
       ["custom-header,upgrade-insecure-requests"]
   end
+
+  describe "the Vary response header" do
+    test "include Origin if the Access-Control-Allow-Origin is not `*`" do
+      opts = CORSPlug.init(origin: "http://example.com")
+      conn =
+        :get
+        |> conn("/")
+        |> put_req_header("origin", "null-example42.com")
+
+      conn = CORSPlug.call(conn, opts)
+      assert ["Origin"] == get_resp_header conn, "vary"
+    end
+
+    test "dont include Origin if the Access-Control-Allow-Origin is `*`" do
+      opts = CORSPlug.init(origin: "*")
+      conn =
+        :get
+        |> conn("/")
+        |> put_req_header("origin", "null-example42.com")
+
+      conn = CORSPlug.call(conn, opts)
+      assert [""] == get_resp_header conn, "vary"
+    end
+  end
 end


### PR DESCRIPTION
> If the server specifies an origin host rather than "*", then it must
> also include Origin in the Vary response header to indicate to clients
> that server responses will differ based on the value of the Origin
> request header.
> -- https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Access-Control-Allow-Origin

Also in the spec: https://www.w3.org/TR/cors/#resource-implementation