### PR TITLE
Gets origin header using exact match instead of regex

### DIFF
--- a/lib/cors_plug.ex
+++ b/lib/cors_plug.ex
@@ -84,6 +84,6 @@ defmodule CORSPlug do
   end
 
   defp request_origin(%Plug.Conn{req_headers: headers}) do
-    Enum.find_value(headers, fn({k, v}) -> k =~ ~r/origin/i && v end)
+    Enum.find_value(headers, fn {k, v} -> k === "origin" && v end)
   end
 end


### PR DESCRIPTION
This change ensures that cors_plug only sources the request origin from the `origin` header. Currently it will use the first header found containing the "origin". In some cases, there may be other headers which match this case such as `akamai-origin-hop`.