### PR TITLE
exact match for origin header regex

### DIFF
--- a/lib/cors_plug.ex
+++ b/lib/cors_plug.ex
@@ -84,6 +84,8 @@ defmodule CORSPlug do
   end
 
   defp request_origin(%Plug.Conn{req_headers: headers}) do
-    Enum.find_value(headers, fn({k, v}) -> k =~ ~r/\Aorigin\z/i && v end)
+    Enum.find_value(headers, fn({name, value}) ->
+      name == "origin" && value
+    end)
   end
 end

--- a/lib/cors_plug.ex
+++ b/lib/cors_plug.ex
@@ -84,6 +84,6 @@ defmodule CORSPlug do
   end
 
   defp request_origin(%Plug.Conn{req_headers: headers}) do
-    Enum.find_value(headers, fn({k, v}) -> k =~ ~r/origin/i && v end)
+    Enum.find_value(headers, fn({k, v}) -> k =~ ~r/\Aorigin\z/i && v end)
   end
 end

--- a/test/cors_plug_test.exs
+++ b/test/cors_plug_test.exs
@@ -24,6 +24,20 @@ defmodule CORSPlugTest do
            get_resp_header(conn, "access-control-allow-origin")
   end
 
+  test "uses exact match origin header" do
+    opts = CORSPlug.init(origin: "example1.com")
+    conn = :get
+      |> conn("/")
+      |> put_req_header("x-origin", "example0.com")
+      |> put_req_header("origin", "example1.com")
+      |> put_req_header("original", "example2.com")
+
+    conn = CORSPlug.call(conn, opts)
+
+    assert ["example1.com"] ==
+           get_resp_header(conn, "access-control-allow-origin")
+  end
+
   test "passes all the relevant headers on an options request" do
     opts = CORSPlug.init([])
     conn = conn(:options, "/")


### PR DESCRIPTION
### problem

regex to find origin header matches first header with "origin" anywhere in header name. so if, e.g., an `x-special-origin` header happens to be first it will match and return that value.

### solution

specify start and end string in regex to _only_ find header with exact (case insensitive) "origin" name.