### PR TITLE
Allow origin and max_age to be resolved at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,27 @@ You can configure allowed origins as follows:
 plug CORSPlug, origin: ["http://example1.com", "http://example2.com"]
 ```
 
-Alternatively, you can use a regex:
+Alternatively, you can:
 
-```elixir
-plug CORSPlug, origin: ~r/https?.*example\d?\.com$/
-```
+  + use a regex:
+
+  ```elixir
+  plug CORSPlug, origin: ~r/https?.*example\d?\.com$/
+  ```
+
+  + resolve from an environment variable
+
+  ```elixir
+  plug CORSPlug, origin: {:system, "SOME_ENV_VAR"}
+  ```
+
+  + resolve from a configuration module
+
+  ```elixir
+  plug CORSPlug, origin: {ConfigModule, :origins}
+  # or passing in arguments
+  plug CORSPlug, origin: {ConfigModule, :origins, ["http", "https"]}
+  ```
 
 Please find the list of current defaults in [cors_plug.ex](lib/cors_plug.ex#L5:L15).
 

--- a/mix.exs
+++ b/mix.exs
@@ -7,6 +7,7 @@ defmodule CorsPlug.Mixfile do
       version: "1.1.4",
       elixir: ">= 1.0.0",
       deps: deps(),
+      elixirc_paths: elixirc_paths(Mix.env),
       package: package(),
       description: description(),
       docs: [
@@ -59,4 +60,7 @@ defmodule CorsPlug.Mixfile do
       }
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_),     do: ["lib"]
 end

--- a/test/support/dummy_module.ex
+++ b/test/support/dummy_module.ex
@@ -1,0 +1,9 @@
+defmodule DummyModule do
+  def example do
+    "http://example.com"
+  end
+
+  def example(nth) do
+    "http://example#{nth}.com"
+  end
+end


### PR DESCRIPTION
When different environments need to use different `origin` and/or `max_age`, allow them to be resolved at runtime from environment variables or configuration modules.