### PR TITLE
Perform list join in init instead of during requests

### DIFF
--- a/lib/cors_plug.ex
+++ b/lib/cors_plug.ex
@@ -1,22 +1,23 @@
 defmodule CORSPlug do
   import Plug.Conn
 
-  def defaults do
-    [
-      origin:      "*",
-      credentials: true,
-      max_age:     1728000,
-      headers:     ["Authorization", "Content-Type", "Accept", "Origin",
-                    "User-Agent", "DNT","Cache-Control", "X-Mx-ReqToken",
-                    "Keep-Alive", "X-Requested-With", "If-Modified-Since",
-                    "X-CSRF-Token"],
-      expose:      [],
-      methods:     ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
-    ]
-  end
+  @defaults [
+    origin:      "*",
+    credentials: true,
+    max_age:     1728000,
+    headers:     ["Authorization", "Content-Type", "Accept", "Origin",
+                  "User-Agent", "DNT","Cache-Control", "X-Mx-ReqToken",
+                  "Keep-Alive", "X-Requested-With", "If-Modified-Since",
+                  "X-CSRF-Token"],
+    expose:      [],
+    methods:     ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
+  ]
 
   def init(options) do
-    Keyword.merge(defaults(), options)
+    @defaults
+    |> Keyword.merge(options)
+    |> Keyword.update!(:expose, &Enum.join(&1, ","))
+    |> Keyword.update!(:methods, &Enum.join(&1, ","))
   end
 
   def call(conn, options) do
@@ -32,7 +33,7 @@ defmodule CORSPlug do
     headers(%{conn | method: nil}, options) ++ [
       {"access-control-max-age", "#{options[:max_age]}"},
       {"access-control-allow-headers", allowed_headers(options[:headers], conn)},
-      {"access-control-allow-methods", Enum.join(options[:methods], ",")}
+      {"access-control-allow-methods", options[:methods]}
     ]
   end
 
@@ -42,7 +43,7 @@ defmodule CORSPlug do
 
     [
       {"access-control-allow-origin", allowed_origin},
-      {"access-control-expose-headers", Enum.join(options[:expose], ",")},
+      {"access-control-expose-headers", options[:expose]},
       {"access-control-allow-credentials", "#{options[:credentials]}"},
       {"vary", vary(allowed_origin)}
     ]

--- a/lib/cors_plug.ex
+++ b/lib/cors_plug.ex
@@ -1,20 +1,22 @@
 defmodule CORSPlug do
   import Plug.Conn
 
-  @defaults [
-    origin:      "*",
-    credentials: true,
-    max_age:     1728000,
-    headers:     ["Authorization", "Content-Type", "Accept", "Origin",
-                  "User-Agent", "DNT","Cache-Control", "X-Mx-ReqToken",
-                  "Keep-Alive", "X-Requested-With", "If-Modified-Since",
-                  "X-CSRF-Token"],
-    expose:      [],
-    methods:     ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
-  ]
+  def defaults do
+    [
+      origin:      "*",
+      credentials: true,
+      max_age:     1728000,
+      headers:     ["Authorization", "Content-Type", "Accept", "Origin",
+                    "User-Agent", "DNT","Cache-Control", "X-Mx-ReqToken",
+                    "Keep-Alive", "X-Requested-With", "If-Modified-Since",
+                    "X-CSRF-Token"],
+      expose:      [],
+      methods:     ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
+    ]
+  end
 
   def init(options) do
-    @defaults
+    defaults()
     |> Keyword.merge(options)
     |> Keyword.update!(:expose, &Enum.join(&1, ","))
     |> Keyword.update!(:methods, &Enum.join(&1, ","))

--- a/test/cors_plug_test.exs
+++ b/test/cors_plug_test.exs
@@ -214,7 +214,6 @@ defmodule CORSPlugTest do
     assert allowed_methods == ["GET,POST,PUT,PATCH,DELETE,OPTIONS"]
   end
 
-
   test "expose headers in options are properly returned" do
     opts = CORSPlug.init(expose: ["X-My-Custom-Header", "X-Another-Custom-Header"])
     conn = conn(:get, "/")

--- a/test/cors_plug_test.exs
+++ b/test/cors_plug_test.exs
@@ -195,4 +195,32 @@ defmodule CORSPlugTest do
     conn = CORSPlug.call(conn, opts)
     assert [""] == get_resp_header conn, "vary"
   end
+
+  test "allowed methods in options are properly returned" do
+    opts = CORSPlug.init(methods: ~w[GET POST])
+    conn = conn(:options, "/")
+    conn = CORSPlug.call(conn, opts)
+
+    allowed_methods = get_resp_header(conn, "access-control-allow-methods")
+    assert allowed_methods == ["GET,POST"]
+  end
+
+  test "default allowed methods are properly returned" do
+    opts = CORSPlug.init([])
+    conn = conn(:options, "/")
+    conn = CORSPlug.call(conn, opts)
+
+    allowed_methods = get_resp_header(conn, "access-control-allow-methods")
+    assert allowed_methods == ["GET,POST,PUT,PATCH,DELETE,OPTIONS"]
+  end
+
+
+  test "expose headers in options are properly returned" do
+    opts = CORSPlug.init(expose: ["X-My-Custom-Header", "X-Another-Custom-Header"])
+    conn = conn(:get, "/")
+    conn = CORSPlug.call(conn, opts)
+
+    expose_headers = get_resp_header(conn, "access-control-expose-headers")
+    assert expose_headers == ["X-My-Custom-Header,X-Another-Custom-Header"]
+  end
 end


### PR DESCRIPTION
Since the lists are very short this will barely be measurable. But
since it happens on every request it probably makes sense to move it
into init