### PR TITLE
Load configuration from config.exs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ Alternatively, you can use a regex:
 plug CORSPlug, origin: ~r/https?.*example\d?\.com$/
 ```
 
+And also you can put configuration into config.exs:
+```elixir
+config :cors_plug,
+  origin: ["foo.bar"],
+  max_age: 86400,
+  methods: ["GET", "POST"]
+```
+Please note that options passed to the plug overrides app config but app config overrides default options.
+
 Please find the list of current defaults in [cors_plug.ex](lib/cors_plug.ex#L5:L15).
 
 ## License

--- a/lib/cors_plug.ex
+++ b/lib/cors_plug.ex
@@ -16,10 +16,17 @@ defmodule CORSPlug do
   end
 
   def init(options) do
-    defaults()
-    |> Keyword.merge(options)
+    options
+    |> prepare_cfg(Application.get_all_env(:cors_plug))
     |> Keyword.update!(:expose, &Enum.join(&1, ","))
     |> Keyword.update!(:methods, &Enum.join(&1, ","))
+  end
+
+  defp prepare_cfg(options, nil), do: Keyword.merge(defaults(), options)
+  defp prepare_cfg(options, env) do
+    defaults()
+    |> Keyword.merge(env)
+    |> Keyword.merge(options)
   end
 
   def call(conn, options) do


### PR DESCRIPTION
Loading configuration from config.exs. Using default value if setting not exists in config.exs.
Now we can separate config for cors_plug between prod, dev and other environments.