### PR TITLE
Allow dynamically configure origins through assign

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,17 @@ config :cors_plug,
   max_age: 86400,
   methods: ["GET", "POST"]
 ```
+
+Also, if you want to dynamically configure origins (base it for example on
+incoming data) you could use assigns:
+```elixir
+conn = conn |> assign(:origin, "example.com")
+```
+
 Please note that options passed to the plug overrides app config but app config overrides default options.
+Be careful though - assigning origin in `conn` will override origin
+configuration elsewhere. This is expected behaviour. Without
+`conn.assing[:origin]` plug with fall back to previous configuration.
 
 Please find the list of current defaults in [cors_plug.ex](lib/cors_plug.ex#L5:L15).
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ incoming data) you could use assigns:
 conn = conn |> assign(:origin, "example.com")
 ```
 
+Or call configure a call to external module via `{module, function}`:
+```elixir
+plug CORSPlug, origin: {MyOrigins, :get_my_origins}
+```
+
 Please note that options passed to the plug overrides app config but app config overrides default options.
 Be careful though - assigning origin in `conn` will override origin
 configuration elsewhere. This is expected behaviour. Without

--- a/lib/cors_plug.ex
+++ b/lib/cors_plug.ex
@@ -49,7 +49,8 @@ defmodule CORSPlug do
 
   # universal headers
   defp headers(conn, options) do
-    allowed_origin = origin(options[:origin], conn)
+    preffered = conn.assigns[:origin] || options[:origin]
+    allowed_origin = origin(preffered, conn)
     vary_header    = vary_header(allowed_origin, get_resp_header(conn, "vary"))
 
     vary_header ++ [

--- a/lib/cors_plug.ex
+++ b/lib/cors_plug.ex
@@ -78,6 +78,16 @@ defmodule CORSPlug do
     if req_origin =~ regex, do: req_origin, else: "null"
   end
 
+  defp origin({mod, fun}, conn) do
+    origins = try do 
+      apply(mod, fun, []) 
+    rescue
+      UndefinedFunctionError ->
+        []
+    end
+    origin(origins, conn)
+  end
+
   # normalize non-list to list
   defp origin(key, conn) when not is_list(key) do
     key

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{"cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:make, :rebar], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
-  "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.16.1", "b4b8a23602b4ce0e9a5a960a81260d1f7b29635b9652c67e95b0c2f7ccee5e81", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
-  "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], []},
-  "plug": {:hex, :plug, "1.3.5", "7503bfcd7091df2a9761ef8cecea666d1f2cc454cbbaf0afa0b6e259203b7031", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
+  "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.16.1", "b4b8a23602b4ce0e9a5a960a81260d1f7b29635b9652c67e95b0c2f7ccee5e81", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], [], "hexpm"},
+  "plug": {:hex, :plug, "1.3.5", "7503bfcd7091df2a9761ef8cecea666d1f2cc454cbbaf0afa0b6e259203b7031", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []}}

--- a/test/cors_plug_test.exs
+++ b/test/cors_plug_test.exs
@@ -1,7 +1,7 @@
 defmodule CORSPlugTest do
   use ExUnit.Case
   use Plug.Test
-  import Plug.Conn, only: [get_resp_header: 2, put_req_header: 3]
+  import Plug.Conn, only: [assign: 3, get_resp_header: 2, put_req_header: 3]
 
   test "returns the right options for regular requests" do
     opts = CORSPlug.init([])
@@ -267,4 +267,19 @@ defmodule CORSPlugTest do
     expose_headers = get_resp_header(conn, "access-control-allow-headers")
     assert expose_headers == ["X-Init-Config-Header"]
   end
+
+  test "takes origin from conn assigns ignoring provided" do
+    opts = CORSPlug.init(origin: "badexample.org")
+    conn = :get
+      |> conn("/")
+      |> put_req_header("origin", "example.com")
+      |> assign(:origin, ["goodexample.com", "example.com"])
+
+    conn = CORSPlug.call(conn, opts)
+
+    assert ["example.com"] ==
+           get_resp_header(conn, "access-control-allow-origin")
+
+  end
+
 end


### PR DESCRIPTION
Hi,

I don't know if you're interested in adding this but here's small enhancement to your plug.

What it does it takes prefferably `conn.assign[:origin]` instead of default configuration, allowing for dynamic configuration of origins (can be set in different, previous plug in pipeline).

There is also possibility of calling module.function to get current origins.

cheers