### PR TITLE
Fix bug: Internal server error on OPTIONS request

### DIFF
--- a/lib/cors_plug.ex
+++ b/lib/cors_plug.ex
@@ -61,9 +61,8 @@ defmodule CORSPlug do
 
   # Allow all requested headers
   defp allowed_headers(["*"], conn) do
-    conn
-    |> get_req_header("access-control-request-headers")
-    |> List.first()
+    headers = get_req_header(conn, "access-control-request-headers")
+    List.first(headers) || ""
   end
 
   defp allowed_headers(key, _conn) do


### PR DESCRIPTION
Internal server error on OPTIONS request when Access-Control-Request-Headers
is not in the request, and `headers: ["*"]` has been set in the config.


--- 

If `Access-Control-Request-Headers` has not been set, it means the author does not intend to send any headers (except [simple headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers)) when the actual request is made. In that case, we can just send an empty value for `Access-Control-Allow-Headers`.
