### PR TITLE
Add send_preflight_response? opt.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,25 @@ def my_fun do
 end
 ```
 
+### send_preflight_response?
+
+There may be times when you would like to retain control over the response sent to OPTIONS requests. If you
+would like CORSPlug to only set headers, then set the `send_preflight_response?` option to false.
+
+```elixir
+plug CORSPlug, send_preflight_response?: false
+
+# or in the app config
+
+config :cors_plug,
+  send_preflight_response?: false
+```
+
 Please note that options passed to the plug overrides app config but app config
 overrides default options.
 
 Please find the list of current defaults in
-[cors_plug.ex](lib/cors_plug.ex#L5:L15).
+[cors_plug.ex](lib/cors_plug.ex#L5:L26).
 
 **As per the [W3C Recommendation](https://www.w3.org/TR/cors/#access-control-allow-origin-response-header)
 the string `null` is returned when no configured origin matched the request.**

--- a/lib/cors_plug.ex
+++ b/lib/cors_plug.ex
@@ -21,7 +21,8 @@ defmodule CORSPlug do
         "X-CSRF-Token"
       ],
       expose: [],
-      methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
+      methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+      send_preflight_response?: true
     ]
   end
 
@@ -43,9 +44,9 @@ defmodule CORSPlug do
   def call(conn, options) do
     conn = merge_resp_headers(conn, headers(conn, options))
 
-    case conn.method do
-      "OPTIONS" -> conn |> send_resp(204, "") |> halt()
-      _method -> conn
+    case {options[:send_preflight_response?], conn.method} do
+      {true, "OPTIONS"} -> conn |> send_resp(204, "") |> halt()
+      {_, _method} -> conn
     end
   end
 

--- a/test/cors_plug_test.exs
+++ b/test/cors_plug_test.exs
@@ -26,6 +26,28 @@ defmodule CORSPlugTest do
     assert ["http://example.com"] == get_resp_header(conn, "access-control-allow-origin")
   end
 
+  test "halts and returns https status 204 for options requests by default" do
+    opts = CORSPlug.init([])
+
+    conn =
+      :options
+      |> conn("/")
+      |> CORSPlug.call(opts)
+
+    assert %Plug.Conn{halted: true, status: 204, state: :sent, resp_body: ""} = conn
+  end
+
+  test "lets me set options requests to not be halted" do
+    opts = CORSPlug.init(send_preflight_response?: false)
+
+    conn =
+      :options
+      |> conn("/")
+      |> CORSPlug.call(opts)
+
+    assert %Plug.Conn{halted: false, status: nil, state: :unset, resp_body: nil} = conn
+  end
+
   test "lets me call a function to resolve origin on every request" do
     opts = CORSPlug.init(origin: fn -> "http://example.com" end)
 


### PR DESCRIPTION
Why:

* There are scenarios where custom OPTIONS requests are needed along
  with CORS. This will allow us to have fine grained control over our
  options requests while still using CORSPlug.

This change addresses the need by:

* Add a send_preflight_response? opt to CORSPlug.