### PR TITLE
Support added to validate cors allowed sites based on conn.

### DIFF
--- a/lib/cors_plug.ex
+++ b/lib/cors_plug.ex
@@ -103,7 +103,11 @@ defmodule CORSPlug do
 
   # get value if origin is a function
   defp origin(fun, conn) when is_function(fun) do
-    origin(fun.(), conn)
+    if is_function(fun,1) do
+        origin(fun.(conn), conn)
+    else
+        origin(fun.(), conn)
+    end
   end
 
   # normalize non-list to list

--- a/test/cors_plug_test.exs
+++ b/test/cors_plug_test.exs
@@ -60,6 +60,18 @@ defmodule CORSPlugTest do
     assert ["http://example.com"] == get_resp_header(conn, "access-control-allow-origin")
   end
 
+  test "lets me call a function with conn as a arg to resolve origin on every request" do
+    opts = CORSPlug.init(origin: fn(conn) -> "http://example.com" end)
+
+    conn =
+      :get
+      |> conn("/")
+      |> put_req_header("origin", "http://example.com")
+      |> CORSPlug.call(opts)
+
+    assert ["http://example.com"] == get_resp_header(conn, "access-control-allow-origin")
+  end
+
   test "passes all the relevant headers on an options request" do
     opts = CORSPlug.init([])
 


### PR DESCRIPTION
Example code:
In case if we want to return allowed sites based on a param(param_name is `myparam`), we have to write code like below example.

File: endpoint.ex
```
Module definition
defmodule CorsValidator do
  def validate(conn) do

    if conn.params["myparam"] == "example" do
      "https://example.com"
    else
      nil #Have to return nil, if we do want any call from other sites.
    end
  end
end

-----------------
plug CORSPlug, origin: &CorsValidator.validate/1

```

Fixes mschae/cors_plug#51