### PR TITLE
Bugfix/missing headers

### DIFF
--- a/lib/cors_plug.ex
+++ b/lib/cors_plug.ex
@@ -85,9 +85,10 @@ defmodule CORSPlug do
 
   # Allow all requested headers
   defp allowed_headers(["*"], conn) do
-    conn
-    |> get_req_header("access-control-request-headers")
-    |> List.first()
+    case get_req_header(conn, "access-control-request-headers") do
+      [ first | _tail] -> first
+      _ -> ""
+    end
   end
 
   defp allowed_headers(key, _conn) do

--- a/test/cors_plug_test.exs
+++ b/test/cors_plug_test.exs
@@ -229,6 +229,17 @@ defmodule CORSPlugTest do
              ["custom-header,upgrade-insecure-requests"]
   end
 
+  test "handles missing access-control-request-headers" do
+    opts = CORSPlug.init(headers: ["*"])
+
+    conn =
+      :options
+      |> conn("/")
+      |> CORSPlug.call(opts)
+
+    assert get_resp_header(conn, "access-control-allow-headers") ==
+             [""]
+  end
   test "dont include Origin in Vary response header if the Origin doesn't match" do
     opts = CORSPlug.init(origin: "http://example.com")
 


### PR DESCRIPTION
Stumbled into a similar problem as #41 

When an incoming request has no `access-control-request-headers` present, the default behaviour fails.

This is because `List.first()` returns `[]` which is treated as `nil` by Plug when merging headers.

This PR adds a default empty string to avoid causing runtime errors.