### PR TITLE
Allow origin function with arity 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,17 @@ config :cors_plug,
 plug CORSPlug, origin: &MyModule.my_fun/0
 
 def my_fun do
-  http://example.com
+  "http://example.com"
+end
+```
+
+You may also use a `function/1` which takes the `conn` as its argument:
+
+```elixir
+plug CORSPlug, origin: &MyModule.my_fun/1
+
+def my_fun(conn) do
+  conn.assigns.cors_allowed_origins
 end
 ```
 

--- a/lib/cors_plug.ex
+++ b/lib/cors_plug.ex
@@ -101,7 +101,12 @@ defmodule CORSPlug do
     if req_origin =~ regex, do: req_origin, else: nil
   end
 
-  # get value if origin is a function
+  # get value if origin is a function with a single argument
+  defp origin(fun, conn) when is_function(fun, 1) do
+    origin(fun.(conn), conn)
+  end
+
+  # get value if origin is a function with no arguments
   defp origin(fun, conn) when is_function(fun) do
     origin(fun.(), conn)
   end

--- a/test/cors_plug_test.exs
+++ b/test/cors_plug_test.exs
@@ -60,6 +60,18 @@ defmodule CORSPlugTest do
     assert ["http://example.com"] == get_resp_header(conn, "access-control-allow-origin")
   end
 
+  test "lets me call a function (with conn) to resolve origin on every request" do
+    opts = CORSPlug.init(origin: fn _conn -> "http://example.com" end)
+
+    conn =
+      :get
+      |> conn("/")
+      |> put_req_header("origin", "http://example.com")
+      |> CORSPlug.call(opts)
+
+    assert ["http://example.com"] == get_resp_header(conn, "access-control-allow-origin")
+  end
+
   test "passes all the relevant headers on an options request" do
     opts = CORSPlug.init([])
 


### PR DESCRIPTION
In my use-case I'm setting different allowed origins for different requests, so I need access to the `conn` in the origins function