### PR TITLE
Fix error when request origin is empty and 'origin' option is a list containing a regex

### DIFF
--- a/lib/cors_plug.ex
+++ b/lib/cors_plug.ex
@@ -135,7 +135,7 @@ defmodule CORSPlug do
   end
 
   defp origin(origins, conn) when is_list(origins) do
-    req_origin = request_origin(conn)
+    req_origin = conn |> request_origin() |> to_string()
 
     cond do
       origin_in_list?(req_origin, origins) -> req_origin

--- a/test/cors_plug_test.exs
+++ b/test/cors_plug_test.exs
@@ -188,6 +188,17 @@ defmodule CORSPlugTest do
     assert [] == get_resp_header(conn, "access-control-allow-origin")
   end
 
+  test "returns no CORS header when origin is null and origin option is a list containing a regex" do
+    opts = CORSPlug.init(origin: [~r/^example.+\.com$/])
+
+    conn =
+      :get
+      |> conn("/")
+      |> CORSPlug.call(opts)
+
+    assert [] == get_resp_header(conn, "access-control-allow-origin")
+  end
+
   test "returns no CORS header when origin does not match origin option regex" do
     opts = CORSPlug.init(origin: ~r/^example.+\.com$/)
 


### PR DESCRIPTION
Fixes #73 

The error is produced when CORSPlug tries to match nil `req_origin` with regex as in `req_origin =~ origin` 

This PR fixes that by converting `req_origin` to string beforehand: 
`req_origin = conn |> request_origin() |> to_string()`