### PR TITLE
Fix compilation warnings on elixir 1.11

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule CorsPlug.Mixfile do
   end
 
   def application do
-    [applications: [:logger]]
+    [extra_applications: [:logger]]
   end
 
   defp deps do


### PR DESCRIPTION
## Motivation

I'm getting the following compilation warnings  on elixir 1.11

```
==> cors_plug
Compiling 1 file (.ex)
warning: Plug.Conn.get_req_header/2 defined in application :plug is used by the current application but the current application does not directly depend on :plug. To fix this, you must do one of:
  1. If :plug is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs
  2. If :plug is a dependency, make sure it is listed under "def deps" in your mix.exs
  3. In case you don't want to add a requirement to :plug, you may optionally skip this warning by adding [xref: [exclude: Plug.Conn]] to your "def project" in mix.exs
  lib/cors_plug.ex:86: CORSPlug.allowed_headers/2
warning: Plug.Conn.get_resp_header/2 defined in application :plug is used by the current application but the current application does not directly depend on :plug. To fix this, you must do one of:
  1. If :plug is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs
  2. If :plug is a dependency, make sure it is listed under "def deps" in your mix.exs
  3. In case you don't want to add a requirement to :plug, you may optionally skip this warning by adding [xref: [exclude: Plug.Conn]] to your "def project" in mix.exs
  lib/cors_plug.ex:66: CORSPlug.headers/2
warning: Plug.Conn.halt/1 defined in application :plug is used by the current application but the current application does not directly depend on :plug. To fix this, you must do one of:
  1. If :plug is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs
  2. If :plug is a dependency, make sure it is listed under "def deps" in your mix.exs
  3. In case you don't want to add a requirement to :plug, you may optionally skip this warning by adding [xref: [exclude: Plug.Conn]] to your "def project" in mix.exs
  lib/cors_plug.ex:34: CORSPlug.call/2
warning: Plug.Conn.merge_resp_headers/2 defined in application :plug is used by the current application but the current application does not directly depend on :plug. To fix this, you must do one of:
  1. If :plug is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs
  2. If :plug is a dependency, make sure it is listed under "def deps" in your mix.exs
  3. In case you don't want to add a requirement to :plug, you may optionally skip this warning by adding [xref: [exclude: Plug.Conn]] to your "def project" in mix.exs
  lib/cors_plug.ex:31: CORSPlug.call/2
warning: Plug.Conn.send_resp/3 defined in application :plug is used by the current application but the current application does not directly depend on :plug. To fix this, you must do one of:
  1. If :plug is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs
  2. If :plug is a dependency, make sure it is listed under "def deps" in your mix.exs
  3. In case you don't want to add a requirement to :plug, you may optionally skip this warning by adding [xref: [exclude: Plug.Conn]] to your "def project" in mix.exs
  lib/cors_plug.ex:34: CORSPlug.call/2
Generated cors_plug app
```
## Proposed Solution

By default, the list of applications to start is automatically inferred from the dependencies. Mix and other tools use the application list in order to start the dependencies before starting the application itself. If we use the `applications:` then no inference is done. This means that for all users of the library, plugs and the other deps that were not included in the applications will not be included as runtime dependencies of `cors_plug`, hence the warning on elixir 1.11.

A quick solution for this is to use the `extra_applications`, in this way we let the compiler infer from the dependencies list the applications that it needs to start.

Links:

- https://elixir-lang.org/blog/2017/01/05/elixir-v1-4-0-released/#application-inference
- https://hexdocs.pm/mix/Mix.Tasks.Compile.App.html
- https://stackoverflow.com/questions/44727642/elixir-mix-file-applications-vs-extra-applications-when-to-use-which