### PR TITLE
Use dependabot to keep dependencies up-to-date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: mix
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    target-branch: master


### PR DESCRIPTION
In your README you state

> Whenever I get around to, I will bump the plug dependency to the latest version of plug.

I thought adding dependabot support might make this easier on you.

If you'd rather not use dependabot then no worries. Just thought I'd put it out there.