### PR TITLE
Updated Elixir and OTP in test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,8 @@ jobs:
     name: OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
     strategy:
       matrix:
-        otp: [20.3, 21.3, 22.2]
-        elixir: [1.7.4, 1.8.2, 1.9.4]
+        otp: [21.x, 22.x, 23.x]
+        elixir: [1.9.x, 1.10.x, 1.11.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1

--- a/test/cors_plug_test.exs
+++ b/test/cors_plug_test.exs
@@ -101,7 +101,7 @@ defmodule CORSPlugTest do
     ]
 
     for header <- required_headers do
-      assert header in Keyword.keys(conn.resp_headers)
+      assert header in Enum.map(conn.resp_headers, fn({ k, _ }) -> k end)
     end
   end
 


### PR DESCRIPTION
In your README you state

> As of Elixir and OTP, my goal is to test against the three most recent versions respectively.

This pull request updates the text matrix to the 3 most recent versions of Elixir and OTP.